### PR TITLE
#12: GET /products/read api (closes #12)

### DIFF
--- a/api/.jvmopts
+++ b/api/.jvmopts
@@ -1,0 +1,4 @@
+-Xms2g
+-Xmx4g
+-Xss2m
+-XX:MetaspaceSize=512m

--- a/api/src/main/scala/cryptonite/Boot.scala
+++ b/api/src/main/scala/cryptonite/Boot.scala
@@ -19,10 +19,12 @@ object Boot extends App with WiroCodecs with RouterDerivationModule {
   val walletService = new WalletService(walletRepo)
   val walletRouter = deriveRouter[WalletController](new WalletControllerImpl(walletService))
 
+  val productsRouter = deriveRouter[ProductsController](new ProductsControllerImpl)
+
   val conf = ConfigFactory.load()
 
   val rpcServer = new HttpRPCServer(
     config = Config(conf.getString("cryptonite.host"), conf.getInt("cryptonite.port")),
-    routers = List(walletRouter)
+    routers = List(walletRouter,productsRouter)
   )
 }

--- a/api/src/main/scala/cryptonite/ProductsController.scala
+++ b/api/src/main/scala/cryptonite/ProductsController.scala
@@ -1,0 +1,31 @@
+package cryptonite
+
+import scala.concurrent.{Future, ExecutionContext}
+import wiro.annotation._
+
+import cryptonite.model._
+import cryptonite.errors.ApiError
+
+@path("products")
+trait ProductsController {
+
+  @query
+  def read(): Future[Either[ApiError, List[Book]]]
+}
+
+class ProductsControllerImpl(implicit ec: ExecutionContext) extends ProductsController {
+
+  override def read(): Future[Either[ApiError, List[Book]]] = Future{
+    Right{ 
+      val list : List[Book] = 
+        new Book(Exchange.GDAX, new Product(Currency.Bitcoin, Currency.Euro), new Amount(11948.02F, Currency.Euro), new Amount(11948.08F, Currency.Euro), new Amount(5974.01F, Currency.Euro)) ::
+        new Book(Exchange.GDAX, new Product(Currency.Bitcoin, Currency.Pound), new Amount(10488.03F, Currency.Pound), new Amount(10516.72F, Currency.Pound), new Amount(5244.015F, Currency.Pound)) ::
+        new Book(Exchange.GDAX, new Product(Currency.Bitcoin, Currency.Dollar), new Amount(13982.6F, Currency.Dollar), new Amount(13984.93F, Currency.Dollar), new Amount(6691.3F, Currency.Dollar)) ::
+        new Book(Exchange.Kraken, new Product(Currency.Litecoin, Currency.Bitcoin), new Amount(0.016978F, Currency.Bitcoin), new Amount(0.017017F, Currency.Bitcoin), new Amount(0F, Currency.Bitcoin)) ::
+        new Book(Exchange.Kraken, new Product(Currency.Bitcoin, Currency.Euro), new Amount(11763.8F, Currency.Euro), new Amount(11763.9F, Currency.Euro), new Amount(5581.9F, Currency.Euro)) ::
+        new Book(Exchange.Kraken, new Product(Currency.Ripple, Currency.Euro), new Amount(1.68000F, Currency.Euro), new Amount(1.68698F, Currency.Euro), new Amount(16.8F, Currency.Euro)) :: Nil
+      list
+    }
+  }
+}
+

--- a/api/src/main/scala/cryptonite/ProductsController.scala
+++ b/api/src/main/scala/cryptonite/ProductsController.scala
@@ -15,17 +15,14 @@ trait ProductsController {
 
 class ProductsControllerImpl(implicit ec: ExecutionContext) extends ProductsController {
 
-  override def read(): Future[Either[ApiError, List[Book]]] = Future{
-    Right{ 
-      val list : List[Book] = 
-        new Book(Exchange.GDAX, new Product(Currency.Bitcoin, Currency.Euro), new Amount(11948.02F, Currency.Euro), new Amount(11948.08F, Currency.Euro), new Amount(5974.01F, Currency.Euro)) ::
-        new Book(Exchange.GDAX, new Product(Currency.Bitcoin, Currency.Pound), new Amount(10488.03F, Currency.Pound), new Amount(10516.72F, Currency.Pound), new Amount(5244.015F, Currency.Pound)) ::
-        new Book(Exchange.GDAX, new Product(Currency.Bitcoin, Currency.Dollar), new Amount(13982.6F, Currency.Dollar), new Amount(13984.93F, Currency.Dollar), new Amount(6691.3F, Currency.Dollar)) ::
-        new Book(Exchange.Kraken, new Product(Currency.Litecoin, Currency.Bitcoin), new Amount(0.016978F, Currency.Bitcoin), new Amount(0.017017F, Currency.Bitcoin), new Amount(0F, Currency.Bitcoin)) ::
-        new Book(Exchange.Kraken, new Product(Currency.Bitcoin, Currency.Euro), new Amount(11763.8F, Currency.Euro), new Amount(11763.9F, Currency.Euro), new Amount(5581.9F, Currency.Euro)) ::
-        new Book(Exchange.Kraken, new Product(Currency.Ripple, Currency.Euro), new Amount(1.68000F, Currency.Euro), new Amount(1.68698F, Currency.Euro), new Amount(16.8F, Currency.Euro)) :: Nil
-      list
-    }
-  }
+  override def read(): Future[Either[ApiError, List[Book]]] = Future(Right(List(
+    new Book(Exchange.GDAX, new Product(Currency.Bitcoin, Currency.Euro), new Amount(11948.02F, Currency.Euro), new Amount(11948.08F, Currency.Euro), new Amount(5974.01F, Currency.Euro)),
+    new Book(Exchange.GDAX, new Product(Currency.Bitcoin, Currency.Pound), new Amount(10488.03F, Currency.Pound), new Amount(10516.72F, Currency.Pound), new Amount(5244.015F, Currency.Pound)),
+    new Book(Exchange.GDAX, new Product(Currency.Bitcoin, Currency.Dollar), new Amount(13982.6F, Currency.Dollar), new Amount(13984.93F, Currency.Dollar), new Amount(6691.3F, Currency.Dollar)),
+    new Book(Exchange.Kraken, new Product(Currency.Litecoin, Currency.Bitcoin), new Amount(0.016978F, Currency.Bitcoin), new Amount(0.017017F, Currency.Bitcoin), new Amount(0F, Currency.Bitcoin)),
+    new Book(Exchange.Kraken, new Product(Currency.Bitcoin, Currency.Euro), new Amount(11763.8F, Currency.Euro), new Amount(11763.9F, Currency.Euro), new Amount(5581.9F, Currency.Euro)),
+    new Book(Exchange.Kraken, new Product(Currency.Ripple, Currency.Euro), new Amount(1.68000F, Currency.Euro), new Amount(1.68698F, Currency.Euro), new Amount(16.8F, Currency.Euro))
+  )))
+
 }
 

--- a/api/src/main/scala/cryptonite/WiroCodecs.scala
+++ b/api/src/main/scala/cryptonite/WiroCodecs.scala
@@ -14,7 +14,7 @@ import cryptonite.errors.ApiError
 
 trait WiroCodecs {
   implicit def apiErrorToResponse: ToHttpResponse[ApiError] = error =>
-    error match { 
+    error match {
       case ApiError.GenericError => HttpResponse(
         status = StatusCodes.InternalServerError,
         entity = error

--- a/api/src/main/scala/cryptonite/model/Book.scala
+++ b/api/src/main/scala/cryptonite/model/Book.scala
@@ -1,0 +1,9 @@
+package cryptonite.model
+
+case class Book (
+  exchange: Exchange,
+  product: Product,
+  bid: Amount,
+  ask: Amount,
+  value: Amount
+)

--- a/api/src/test/scala/cryptonite/WalletServiceSpec.scala
+++ b/api/src/test/scala/cryptonite/WalletServiceSpec.scala
@@ -11,7 +11,7 @@ import cryptonite.model.Amount
 class WalletServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
 
   type FixtureParam = WalletService
-  
+
   def withFixture(test: OneArgAsyncTest): FutureOutcome = {
     val service = new WalletService(new WalletRepository())
     withFixture(test.toNoArgAsyncTest(service))
@@ -22,13 +22,13 @@ class WalletServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
   }
 
   implicit private class Check[E,R](fut: Future[Either[E,R]]) {
-    def checkFutureResult(g: R => Assertion): Future[Assertion] = 
+    def checkFutureResult(g: R => Assertion): Future[Assertion] =
       fut.map(_.fold(
         error => fail(error.toString),
         g
       ))
 
-    def checkFutureError(h: E => Assertion): Future[Assertion] = 
+    def checkFutureError(h: E => Assertion): Future[Assertion] =
       fut.map(_.fold(
         h,
         result => fail("Unexpected result")


### PR DESCRIPTION
Closes #12

Implements the GET /products/read API.
Currently it returns mocked data, it will be integrated with GDAX api later

## Test Plan

### tests performed
GET http://localhost:8080/products/read
returns the mocked data
