### PR TITLE
#11: POST /portfolio/save api (closes #11)

### DIFF
--- a/api/src/main/scala/cryptonite/PortfolioController.scala
+++ b/api/src/main/scala/cryptonite/PortfolioController.scala
@@ -11,10 +11,15 @@ trait PortfolioController {
 
   @query
   def read(): Future[Either[ApiError, List[Amount]]]
+
+  @command
+  def save(amounts: List[Amount]): Future[Either[ApiError, Unit]]
 }
 
 class PortfolioControllerImpl(service: PortfolioService) extends PortfolioController {
 
   override def read(): Future[Either[ApiError, List[Amount]]] = service.read()
+
+  override def save(amounts: List[Amount]): Future[Either[ApiError, Unit]] = service.save(amounts)
 }
 

--- a/api/src/main/scala/cryptonite/PortfolioRepository.scala
+++ b/api/src/main/scala/cryptonite/PortfolioRepository.scala
@@ -11,6 +11,8 @@ class PortfolioRepository {
 
   def get(code: String): Option[Amount] = portfolio.get(code)
 
+  def save(amounts: List[Amount]): Unit = amounts.foreach { x => portfolio.put(x.currency.index.code, x) }
+
   private def initializePortfolio(): TrieMap[String, Amount] = {
     val portfolio: TrieMap[String, Amount] = new TrieMap()
     val currencies: Set[Amount] = CaseEnumSerialization[Currency].values.map(new Amount(0.0F,_))

--- a/api/src/main/scala/cryptonite/PortfolioService.scala
+++ b/api/src/main/scala/cryptonite/PortfolioService.scala
@@ -21,11 +21,10 @@ class PortfolioService(repository: PortfolioRepository)(implicit ec: ExecutionCo
   }
 
   def save(amounts: List[Amount]): Future[Either[ApiError, Unit]] = Future {
-    val currenciesSet = CaseEnumSerialization[Currency].values
-    val currenciesSize = currenciesSet.size
-    (amounts.size, amounts.map(_.currency).toSet) match {
-      case (currenciesSize, currenciesSet) => Right(repository.save(amounts))
-      case _ => Left(ApiError.PortfolioMismatchError)
-    }
+    val currencies = CaseEnumSerialization[Currency].values.toList.sortBy(_.index.code)
+    if (currencies.sameElements(amounts.map(_.currency).sortBy(_.index.code)))
+      Right(repository.save(amounts))
+    else
+      Left(ApiError.PortfolioMismatchError)
   }
 }

--- a/api/src/main/scala/cryptonite/PortfolioService.scala
+++ b/api/src/main/scala/cryptonite/PortfolioService.scala
@@ -21,7 +21,7 @@ class PortfolioService(repository: PortfolioRepository)(implicit ec: ExecutionCo
   }
 
   def save(amounts: List[Amount]): Future[Either[ApiError, Unit]] = Future {
-    val currencies = CaseEnumSerialization[Currency].values.toList.sortBy(_.index.code)
+    val currencies = CaseEnumSerialization[Currency].values.toList.filter(_.index.isCrypto).sortBy(_.index.code)
     if (currencies.sameElements(amounts.map(_.currency).sortBy(_.index.code)))
       Right(repository.save(amounts))
     else

--- a/api/src/main/scala/cryptonite/PortfolioService.scala
+++ b/api/src/main/scala/cryptonite/PortfolioService.scala
@@ -2,7 +2,9 @@ package cryptonite
 
 import scala.concurrent.{Future, ExecutionContext}
 
-import cryptonite.model.Amount
+import io.buildo.enumero.CaseEnumSerialization
+
+import cryptonite.model.{ Amount, Currency }
 import cryptonite.errors.ApiError
 
 class PortfolioService(repository: PortfolioRepository)(implicit ec: ExecutionContext) {
@@ -15,6 +17,15 @@ class PortfolioService(repository: PortfolioRepository)(implicit ec: ExecutionCo
     repository.get(code) match {
       case Some(amount) => Right(amount)
       case None => Left(ApiError.CurrencyNotFoundError)
+    }
+  }
+
+  def save(amounts: List[Amount]): Future[Either[ApiError, Unit]] = Future {
+    val currenciesSet = CaseEnumSerialization[Currency].values
+    val currenciesSize = currenciesSet.size
+    (amounts.size, amounts.map(_.currency).toSet) match {
+      case (currenciesSize, currenciesSet) => Right(repository.save(amounts))
+      case _ => Left(ApiError.PortfolioMismatchError)
     }
   }
 }

--- a/api/src/main/scala/cryptonite/WiroCodecs.scala
+++ b/api/src/main/scala/cryptonite/WiroCodecs.scala
@@ -22,6 +22,10 @@ trait WiroCodecs {
         status = StatusCodes.InternalServerError,
         entity = error
       )
+      case ApiError.PortfolioMismatchError => HttpResponse(
+        status = StatusCodes.BadRequest,
+        entity = error
+      )
     }
 
   private implicit def entityToJson[E](entity: E)(implicit encoder: Encoder[E]): HttpEntity.Strict = HttpEntity(

--- a/api/src/main/scala/cryptonite/errors/Errors.scala
+++ b/api/src/main/scala/cryptonite/errors/Errors.scala
@@ -5,4 +5,5 @@ import io.buildo.enumero.annotations.enum
 @enum trait ApiError {
   object GenericError
   object CurrencyNotFoundError
+  object PortfolioMismatchError
 }

--- a/api/src/test/scala/cryptonite/PortfolioServiceSpec.scala
+++ b/api/src/test/scala/cryptonite/PortfolioServiceSpec.scala
@@ -5,10 +5,32 @@ import scala.concurrent.Future
 import org.scalatest._
 import org.scalatest.Matchers._
 
-import cryptonite.errors.ApiError
-import cryptonite.model.Amount
+import cryptonite.model.{ Amount, Currency }
 
 class PortfolioServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
+
+  val amountsToBeSaved = List(
+    new Amount(10.0F, Currency.Bitcoin),
+    new Amount(5.374F, Currency.BitcoinCash),
+    new Amount(34.23F, Currency.Litecoin),
+    new Amount(8.9231F, Currency.Ethereum),
+    new Amount(3.474243F, Currency.Ripple),
+    new Amount(5.329874F, Currency.Cardano),
+    new Amount(2.374F, Currency.NEM),
+    new Amount(200.15F, Currency.Stellar),
+    new Amount(1900.234F, Currency.IOTA),
+    new Amount(1738.0F, Currency.TRON),
+    new Amount(143.0F, Currency.Dash),
+    new Amount(972.0F, Currency.NEO),
+    new Amount(2.0F, Currency.Monero),
+    new Amount(34.0F, Currency.EOS),
+    new Amount(7.5F, Currency.ICON),
+    new Amount(3.4F, Currency.Qtum),
+    new Amount(3.3F, Currency.BitcoinGold),
+    new Amount(70.5F, Currency.Lisk),
+    new Amount(10.2F, Currency.RaiBlocks),
+    new Amount(19.2F, Currency.EthereumClassic)
+  )
 
   type FixtureParam = PortfolioService
 
@@ -19,6 +41,10 @@ class PortfolioServiceSpec extends fixture.AsyncFlatSpec with EitherValues {
 
   "The portfolio service" should "return a list of amounts of supported cryptocurrencies when the read method is invoked" in { service =>
     service.read().checkFutureResult(_ should have size 20)
+  }
+
+  "The portfolio service" should "should successfully save a valid list of amounts in the portfolio" in { service =>
+    service.save(amountsToBeSaved).checkFutureResult(_ => succeed)
   }
 
   implicit private class Check[E,R](fut: Future[Either[E,R]]) {


### PR DESCRIPTION
Closes #11

Implements POST /portfolio/save API
The API requires a list of amounts in input, that should contain one entry for every currency supported by Cryptonite.

## Test Plan

PortfolioServiceSpec updated

### tests performed

sbt test showing 2 successful tests
