### PR TITLE
#49: Implement caching of external API calls in backend (closes #49)

### DIFF
--- a/api/build.sbt
+++ b/api/build.sbt
@@ -16,6 +16,7 @@ lazy val sttpCirce = "com.softwaremill.sttp" %% "circe" % sttpVersion
 lazy val sttpAkka = "com.softwaremill.sttp" %% "akka-http-backend" % sttpVersion
 lazy val catsCore = "org.typelevel" %% "cats-core" % "0.9.0"
 lazy val logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
+lazy val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "0.22.0"
 lazy val root = project.in(file("."))
   .settings(
     name := "cryptonite",
@@ -36,7 +37,8 @@ lazy val root = project.in(file("."))
       sttpCirce,
       sttpAkka,
       catsCore,
-      logback
+      logback,
+      scalaCache
     ),
     addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   )


### PR DESCRIPTION
Closes #49

Implements caching of external API calls

## Test Plan

### tests performed

End to end tests

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
